### PR TITLE
simplify readOID by reusing readString

### DIFF
--- a/lib/ber/reader.js
+++ b/lib/ber/reader.js
@@ -183,28 +183,15 @@ Reader.prototype.readOID = function(tag) {
   if (!tag)
     tag = ASN1.OID;
 
-  var b = this.peek();
+  var b = this.readString(tag, true);
   if (b === null)
     return null;
-
-  if (b !== tag)
-    throw newInvalidAsn1Error('Expected 0x' + tag.toString(16) +
-                              ': got 0x' + b.toString(16));
-
-  var o = this.readLength(this._offset + 1); // stored in `length`
-  if (o === null)
-    return null;
-
-  if (this.length > this._size - o)
-    return null;
-
-  this._offset = o;
 
   var values = [];
   var value = 0;
 
-  for (var i = 0; i < this.length; i++) {
-    var byte = this._buf[this._offset++] & 0xff;
+  for (var i = 0; i < b.length; i++) {
+    var byte = b[i] & 0xff;
 
     value <<= 7;
     value += byte & 0x7f;


### PR DESCRIPTION
i realised after my last pull request that half of readOID is the same code as all of readString, so why not just use readString to do that work?
