### PR TITLE
WRITER: ensure that no value greater than 0xFF is written to a buffer position.

### DIFF
--- a/lib/ber/writer.js
+++ b/lib/ber/writer.js
@@ -233,14 +233,14 @@ Writer.prototype.writeLength = function(len) {
     this._buf[this._offset++] = len;
   } else if (len <= 0xffff) {
     this._buf[this._offset++] = 0x82;
-    this._buf[this._offset++] = len >> 8;
-    this._buf[this._offset++] = len;
+    this._buf[this._offset++] = (len >> 8) & 0xff;
+    this._buf[this._offset++] = len & 0xff;
   } else if (len <= 0xffffff) {
     this._shift(start, len, 1);
     this._buf[this._offset++] = 0x83;
-    this._buf[this._offset++] = len >> 16;
-    this._buf[this._offset++] = len >> 8;
-    this._buf[this._offset++] = len;
+    this._buf[this._offset++] = (len >> 16) & 0xff;
+    this._buf[this._offset++] = (len >> 8) & 0xff;
+    this._buf[this._offset++] = len & 0xff;
   } else {
     throw new InvalidAsn1ERror('Length too long (> 4 bytes)');
   }
@@ -271,14 +271,14 @@ Writer.prototype.endSequence = function() {
     this._buf[seq + 1] = len;
   } else if (len <= 0xffff) {
     this._buf[seq] = 0x82;
-    this._buf[seq + 1] = len >> 8;
-    this._buf[seq + 2] = len;
+    this._buf[seq + 1] = (len >> 8) & 0xff;
+    this._buf[seq + 2] = len & 0xff;
   } else if (len <= 0xffffff) {
     this._shift(start, len, 1);
     this._buf[seq] = 0x83;
-    this._buf[seq + 1] = len >> 16;
-    this._buf[seq + 2] = len >> 8;
-    this._buf[seq + 3] = len;
+    this._buf[seq + 1] = (len >> 16) & 0xff;
+    this._buf[seq + 2] = (len >> 8) & 0xff;
+    this._buf[seq + 3] = len & 0xff;
   } else {
     throw new InvalidAsn1Error('Sequence too long');
   }


### PR DESCRIPTION
NodeJS seems to automatically truncate values when writing to a buffer, mainly because NodeJS relies on native buffers.

However, when using this module in the browser (via browserify, or any other portability tool), the buffer is implemented in javascript which will accept values > 0xFF leading to malformed outputs of the writer. 

The unit tests pass with this patch included.
