### PR TITLE
fix typo

### DIFF
--- a/lib/ber/writer.js
+++ b/lib/ber/writer.js
@@ -160,7 +160,7 @@ Writer.prototype.writeBuffer = function(buf, tag) {
 
 
 Writer.prototype.writeStringArray = function(strings) {
-  if ((!strings instanceof Array))
+  if (!(strings instanceof Array))
     throw new TypeError('argument must be an Array[String]');
 
   var self = this;


### PR DESCRIPTION
I found a meaningless if condition which always become false, because not operator(`!`) is evaluated before the `instanceof` operator.
