### PR TITLE
Create .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,2 @@
+tst/
+.travis.yml


### PR DESCRIPTION
Remove redundant files from the node_modules folder. For more background information, see https://gist.github.com/greim/e8e1bd3b1ed08a7505ce#second-missing-or-incomplete-npmignore-files