### PR TITLE
fix: writeStringArray has wrong check

### DIFF
--- a/lib/ber/writer.js
+++ b/lib/ber/writer.js
@@ -161,7 +161,7 @@ Writer.prototype.writeBuffer = function (buf, tag) {
 
 
 Writer.prototype.writeStringArray = function (strings) {
-  if ((!strings instanceof Array))
+  if (!(strings instanceof Array))
     throw new TypeError('argument must be an Array[String]');
 
   var self = this;


### PR DESCRIPTION
`!strings instanceof Array` is parsed as `(!strings) instanceof Array`, which is not what this should check for. The `!` need to be outside to actually test the instance type first.