### PR TITLE
Remove safer-buffer dependency

### DIFF
--- a/lib/ber/reader.js
+++ b/lib/ber/reader.js
@@ -1,11 +1,9 @@
 // Copyright 2011 Mark Cavage <mcavage@gmail.com> All rights reserved.
 
-var assert = require('assert');
-var Buffer = require('safer-buffer').Buffer;
+var assert = require("assert");
 
-var ASN1 = require('./types');
-var errors = require('./errors');
-
+var ASN1 = require("./types");
+var errors = require("./errors");
 
 // --- Globals
 

--- a/lib/ber/writer.js
+++ b/lib/ber/writer.js
@@ -1,10 +1,8 @@
 // Copyright 2011 Mark Cavage <mcavage@gmail.com> All rights reserved.
 
-var assert = require('assert');
-var Buffer = require('safer-buffer').Buffer;
-var ASN1 = require('./types');
-var errors = require('./errors');
-
+var assert = require("assert");
+var ASN1 = require("./types");
+var errors = require("./errors");
 
 // --- Globals
 

--- a/package.json
+++ b/package.json
@@ -8,15 +8,13 @@
   ],
   "name": "asn1",
   "description": "Contains parsers and serializers for ASN.1 (currently BER only)",
-  "version": "0.2.6",
+  "version": "0.3.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/joyent/node-asn1.git"
   },
   "main": "lib/index.js",
-  "dependencies": {
-    "safer-buffer": "~2.1.0"
-  },
+  "dependencies": {},
   "devDependencies": {
     "istanbul": "^0.3.6",
     "faucet": "0.0.1",


### PR DESCRIPTION
Having this and bundling it with vite for an electron app creates two different imports of Buffer, which then fails the Buffer.isBuffer check.