### PR TITLE
Remove an impossible check in `Reader.prototype.readLength`

### DIFF
--- a/lib/ber/reader.js
+++ b/lib/ber/reader.js
@@ -90,8 +90,6 @@ Reader.prototype.readLength = function (offset) {
     return null;
 
   var lenB = this._buf[offset++] & 0xff;
-  if (lenB === null)
-    return null;
 
   if ((lenB & 0x80) === 0x80) {
     lenB &= 0x7f;


### PR DESCRIPTION
Removes the impossible "if (lenB === null)" check, since it is impossible for it to be null because of the "& 0xff" on the previous line.

According the the spec (https://262.ecma-international.org/#sec-numberbitwiseop), the result of `this._buf[offset++] & 0xff` (call to the internal `NumberBitwiseOp(&, this._buf[offset++], 0xff)`) must be an integer unless it throws. It may throw because `ToInt32` (https://262.ecma-international.org/#sec-toint32) calls `ToNumber` (https://262.ecma-international.org/#sec-tonumber) which throws if the argument is a Symbol or BigInt. I tested many combinations of `thing & 0xff` in multiple versions of Node; and have not yet found a case where this part of the spec is false.

Since it may never be null, the lines 93 and 94 that say `if (lenB === null) return null` are basically a no-op.
Removing it should not be a breaking change for anyone.

It's not much, but it may shave off a few bytes and CPU cycles.